### PR TITLE
add read-write key to .circleci release_latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,9 @@ jobs:
     <<: *default_env
     steps:
       - setup_job
+      - add_ssh_keys:
+          fingerprints:
+            - "46:a6:69:50:02:75:c5:bc:93:c8:52:96:b6:90:0e:70"
       - run:
           name: Publish "latest" release
           command: yarn publish:ci:latest


### PR DESCRIPTION
The release_latest step in .circleci requires an ssh key with write access to push version tags to the git repo. 

After this is merged CircleCI should pass again: https://app.circleci.com/pipelines/github/IndexCoop/index-protocol/74/workflows/18fa208b-71fa-4d52-b01a-7ffc4232e5e6