### PR TITLE
chore(fix): Remove unnecessary import

### DIFF
--- a/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
+++ b/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
@@ -34,7 +34,6 @@ import {
 } from "@utils/test/index";
 import { SystemFixture } from "@utils/fixtures";
 import { ContractTransaction } from "ethers";
-import { before } from "mocha";
 
 const expect = getWaffleExpect();
 


### PR DESCRIPTION
Should patch the github actions error in https://github.com/IndexCoop/index-protocol/commit/07c6a80e4f723a0141d95750556fedf3558a9922
`TypeError: (0 , mocha_1.before) is not a function`