### PR TITLE
fix(module): Add AuctionRebalanceModuleV1 Audit Remediations

### DIFF
--- a/contracts/protocol/integration/auction-price/BoundedStepwiseExponentialPriceAdapter.sol
+++ b/contracts/protocol/integration/auction-price/BoundedStepwiseExponentialPriceAdapter.sol
@@ -55,7 +55,7 @@ contract BoundedStepwiseExponentialPriceAdapter {
         uint256 timeBucket = _timeElapsed / bucketSize;
 
         // Protect against exponential argument overflow
-        if (timeBucket > type(uint256).max / timeCoefficient) {
+        if (timeBucket > uint256(type(int256).max) / timeCoefficient) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
         int256 expArgument = int256(timeCoefficient * timeBucket);
@@ -70,7 +70,7 @@ contract BoundedStepwiseExponentialPriceAdapter {
         if (scalingFactor > type(uint256).max / expExpression) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
-        uint256 priceChange = scalingFactor * expExpression - WAD;
+        uint256 priceChange = FixedPointMathLib.mulWad(scalingFactor, expExpression - WAD);
 
         if (isDecreasing) {
             // Protect against price underflow

--- a/contracts/protocol/integration/auction-price/BoundedStepwiseLogarithmicPriceAdapter.sol
+++ b/contracts/protocol/integration/auction-price/BoundedStepwiseLogarithmicPriceAdapter.sol
@@ -55,7 +55,7 @@ contract BoundedStepwiseLogarithmicPriceAdapter {
         uint256 timeBucket = _timeElapsed / bucketSize;
 
         // Protect against logarithmic argument overflow
-        if (timeBucket > type(uint256).max / timeCoefficient) {
+        if (timeBucket > uint256(type(int256).max) / timeCoefficient) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
         int256 lnArgument = int256(timeBucket * timeCoefficient);
@@ -70,7 +70,7 @@ contract BoundedStepwiseLogarithmicPriceAdapter {
         if (lnExpression > type(uint256).max / scalingFactor) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
-        uint256 priceChange = scalingFactor * lnExpression;
+        uint256 priceChange = FixedPointMathLib.mulWad(scalingFactor, lnExpression);
 
         if (isDecreasing) {
             // Protect against price underflow

--- a/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
+++ b/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
@@ -45,6 +45,10 @@ import { PreciseUnitMath } from "../../../lib/PreciseUnitMath.sol";
  *
  * @dev Compatible with StreamingFeeModule and BasicIssuanceModule. Review compatibility if used
  * with additional modules.
+ * @dev WARNING: This contract does NOT support ERC-777 component tokens or quote assets.
+ * @dev WARNING: Please note that the behavior of block.timestamp varies across different EVM chains. 
+ * This contract does not incorporate additional checks for unique behavior or for elements like sequencer uptime. 
+ * Ensure you understand these characteristics when interacting with the contract on different EVM chains.
  */
 contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
     using SafeCast for int256;

--- a/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
+++ b/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
@@ -45,6 +45,10 @@ import { PreciseUnitMath } from "../../../lib/PreciseUnitMath.sol";
  *
  * @dev Compatible with StreamingFeeModule and BasicIssuanceModule. Review compatibility if used
  * with additional modules.
+ * @dev WARNING: If rebalances don't lock the SetToken, there's potential for bids to be front-run
+ * by sizable issuance/redemption. This could lead to the SetToken not approaching its target allocation
+ * proportionately to the bid size. To counteract this risk, a supply cap can be applied to the SetToken,
+ * allowing regular issuance/redemption while preventing front-running with large issuance/redemption.
  * @dev WARNING: This contract does NOT support ERC-777 component tokens or quote assets.
  * @dev WARNING: Please note that the behavior of block.timestamp varies across different EVM chains. 
  * This contract does not incorporate additional checks for unique behavior or for elements like sequencer uptime. 
@@ -231,6 +235,8 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
      * target units, e.g., in cases where fee accrual affects the positionMultiplier of the SetToken, ensuring proportional
      * allocation among components. If target allocations are not met within the specified duration, the rebalance concludes
      * with the allocations achieved.
+     * 
+     * @dev WARNING: If rebalances don't lock the SetToken, enforce a supply cap on the SetToken to prevent front-running.
      *
      * @param _setToken                     The SetToken to be rebalanced.
      * @param _quoteAsset                   ERC20 token used as the quote asset in auctions.
@@ -290,7 +296,8 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
      * is used to push the current component units closer to the target units defined in startRebalance().
      *
      * Bidders specify the amount of the component they intend to buy or sell, and also specify the maximum/minimum amount 
-     * of the quote asset they are willing to spend/receive.
+     * of the quote asset they are willing to spend/receive. If the component amount is max uint256, the bid will fill
+     * the remaining amount to reach the target.
      *
      * The auction parameters, which are set by the manager, are used to determine the price of the component. Any bids that 
      * either don't move the component units towards the target, or overshoot the target, will be reverted.
@@ -321,7 +328,7 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
         onlyAllowedBidder(_setToken)
     {
         // Validate whether the bid targets are legitimate
-        _validateBidTargets(_setToken, _component);
+        _validateBidTargets(_setToken, _component, _componentAmount);
 
         // Create the bid information structure
         BidInfo memory bidInfo = _createBidInfo(_setToken, _component, _componentAmount, _quoteAssetLimit);
@@ -386,7 +393,7 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
     /**
      * @dev Unlocks the SetToken after rebalancing. Can be called once the rebalance duration has elapsed.
      * Can only be called before the rebalance duration has elapsed if all targets are met, there is excess
-     * or at-target quote asset, and raiseTargetPercentage is zero.
+     * or at-target quote asset, and raiseTargetPercentage is zero. Resets the raiseTargetPercentage to zero.
      *
      * @param _setToken The SetToken to be unlocked.
      */
@@ -402,6 +409,9 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
             delete rebalanceInfo[_setToken].rebalanceDuration;
             emit LockedRebalanceEndedEarly(_setToken);
         }
+
+        // Reset the raiseTargetPercentage to zero
+        rebalanceInfo[_setToken].raiseTargetPercentage = 0;
 
         // Unlock the SetToken
         _setToken.unlock();
@@ -421,9 +431,6 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
         external
         onlyManagerAndValidSet(_setToken)
     {
-        // Ensure the raise target percentage is greater than 0
-        require(_raiseTargetPercentage > 0, "Target percentage must be greater than 0");
-
         // Update the raise target percentage in the RebalanceInfo struct
         rebalanceInfo[_setToken].raiseTargetPercentage = _raiseTargetPercentage;
 
@@ -617,7 +624,7 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
         onlyValidAndInitializedSet(_setToken)
         returns (BidInfo memory)
     {
-        _validateBidTargets(_setToken, _component);
+        _validateBidTargets(_setToken, _component, _componentQuantity);
         BidInfo memory bidInfo = _createBidInfo(_setToken, _component, _componentQuantity, _quoteQuantityLimit);
         
         return bidInfo;
@@ -739,13 +746,15 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
     /**
      * @dev Validates that the component is an eligible target for bids during the rebalance. Bids cannot be placed explicitly
      * on the rebalance quote asset, it may only be implicitly bid by being the quote asset for other component bids.
-     *
-     * @param _setToken     The SetToken instance involved in the rebalance.
-     * @param _component    The component to be validated.
+     * 
+     * @param _setToken          The SetToken instance involved in the rebalance.
+     * @param _component         The component to be validated.
+     * @param _componentAmount   The amount of component in the bid.
      */
     function _validateBidTargets(
         ISetToken _setToken,
-        IERC20 _component
+        IERC20 _component,
+        uint256 _componentAmount
     )
         internal
         view
@@ -761,6 +770,9 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
 
         // Ensure that the rebalance is in progress.
         require(!_isRebalanceDurationElapsed(_setToken), "Rebalance must be in progress");
+
+        // Ensure that the component amount is greater than zero.
+        require(_componentAmount > 0, "Component amount must be > 0");
     }
 
     /**
@@ -796,8 +808,13 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
             bidInfo.setTotalSupply
         );
 
+        // Settle the auction if the component quantity is max uint256.
         // Ensure that the component quantity in the bid does not exceed the available auction quantity.
-        require(_componentQuantity <= bidInfo.auctionQuantity, "Bid size exceeds auction quantity");
+        if (_componentQuantity == type(uint256).max) {
+            _componentQuantity = bidInfo.auctionQuantity;
+        } else {
+            require(_componentQuantity <= bidInfo.auctionQuantity, "Bid size exceeds auction quantity");
+        }
 
         // Set the sendToken and receiveToken based on the auction type (sell or buy).
         (bidInfo.sendToken, bidInfo.receiveToken) = _getSendAndReceiveTokens(bidInfo.isSellAuction, _setToken, _component);

--- a/test/protocol/integration/auction-price/boundedStepwiseExponentialPriceAdapter.spec.ts
+++ b/test/protocol/integration/auction-price/boundedStepwiseExponentialPriceAdapter.spec.ts
@@ -48,7 +48,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getPrice", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -60,7 +60,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = true;
@@ -371,7 +371,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
       describe("when the coefficient is 0", async () => {
         beforeEach(async () => {
-          subjectCoefficient = 0;
+          subjectCoefficient = ZERO;
           subjectPriceAdapterConfigData = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             subjectInitialPrice,
             subjectCoefficient,
@@ -468,7 +468,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#isPriceAdapterConfigDataValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -479,7 +479,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -530,7 +530,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     describe("when the coefficient is 0", async () => {
       beforeEach(async () => {
-        subjectCoefficient = 0;
+        subjectCoefficient = ZERO;
         subjectPriceAdapterConfigData = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
           subjectInitialPrice,
           subjectCoefficient,
@@ -743,7 +743,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getDecodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -754,7 +754,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -802,7 +802,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getEncodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -811,7 +811,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;

--- a/test/protocol/integration/auction-price/boundedStepwiseLogarithmicPriceAdapter.spec.ts
+++ b/test/protocol/integration/auction-price/boundedStepwiseLogarithmicPriceAdapter.spec.ts
@@ -48,7 +48,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getPrice", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -60,7 +60,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = true;
@@ -146,7 +146,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
     describe("when the time elapsed is 0", async () => {
       beforeEach(async () => {
         subjectInitialPrice = ether(100);
-        subjectScalingFactor = 1;
+        subjectScalingFactor = ether(1);
         subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
         subjectBucketSize = ONE_HOUR_IN_SECONDS;
         subjectIsDecreasing = true;
@@ -304,7 +304,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is decreasing and the price computation will underflow", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 50;
+        subjectScalingFactor = ether(50);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
@@ -328,7 +328,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is decreasing and the price computation returns below the minimum", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 3;
+        subjectScalingFactor = ether(3);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
@@ -378,7 +378,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is not decreasing and the price computation returns above the maximum", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 3;
+        subjectScalingFactor = ether(3);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectIsDecreasing = false;
         subjectMaxPrice = ether(110);
@@ -425,7 +425,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
       describe("when the scaling factor is 0", async () => {
         beforeEach(async () => {
-          subjectScalingFactor = 0;
+          subjectScalingFactor = ZERO;
           subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             subjectInitialPrice,
             subjectScalingFactor,
@@ -522,7 +522,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#isPriceAdapterConfigDataValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -533,7 +533,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -584,7 +584,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when the scaling factor is 0", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 0;
+        subjectScalingFactor = ZERO;
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
           subjectScalingFactor,
@@ -690,7 +690,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#areParamsValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectMaxPrice: BigNumber;
@@ -698,7 +698,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectMaxPrice = ether(110);
@@ -736,7 +736,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when the scaling factor is 0", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 0;
+        subjectScalingFactor = ZERO;
       });
 
       it("should return false", async () => {
@@ -797,7 +797,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getDecodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -808,7 +808,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -856,7 +856,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getEncodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -865,7 +865,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;

--- a/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
+++ b/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
@@ -2977,7 +2977,7 @@ describe("AuctionRebalanceModuleV1", () => {
         beforeEach(async () => {
           const daiExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(0.0005),
-            1,
+            ether(1),
             ether(0.00001),
             ONE_HOUR_IN_SECONDS,
             true,
@@ -2988,7 +2988,7 @@ describe("AuctionRebalanceModuleV1", () => {
           const wbtcPerWethDecimalFactor = ether(1).div(bitcoin(1));
           const wbtcExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(14.5).mul(wbtcPerWethDecimalFactor),
-            1,
+            ether(1),
             ether(0.1).mul(wbtcPerWethDecimalFactor),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -2998,7 +2998,7 @@ describe("AuctionRebalanceModuleV1", () => {
 
           const wethExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(1),
-            1,
+            ether(1),
             ether(0.1),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -3164,7 +3164,7 @@ describe("AuctionRebalanceModuleV1", () => {
         beforeEach(async () => {
           const daiLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(0.0005),
-            1,
+            ether(1),
             ether(0.00001),
             ONE_HOUR_IN_SECONDS,
             true,
@@ -3175,7 +3175,7 @@ describe("AuctionRebalanceModuleV1", () => {
           const wbtcPerWethDecimalFactor = ether(1).div(bitcoin(1));
           const wbtcLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(14.5).mul(wbtcPerWethDecimalFactor),
-            1,
+            ether(1),
             ether(0.1).mul(wbtcPerWethDecimalFactor),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -3185,7 +3185,7 @@ describe("AuctionRebalanceModuleV1", () => {
 
           const wethLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(1),
-            1,
+            ether(1),
             ether(0.1),
             ONE_HOUR_IN_SECONDS,
             false,


### PR DESCRIPTION
Remediations
+ Adapter: Fix overflow checks in logarithmic and exponential adapters ([Sherlock Issue 1](https://github.com/sherlock-audit/2023-06-Index-judging/issues/1))
+ Module: Add check to prevent bid with `componentAmount = 0` ([Sherlock Issue 6](https://github.com/sherlock-audit/2023-06-Index-judging/issues/6))
+ Warning: ERC-777 incompatibility ([Sherlock Issue 21](https://github.com/sherlock-audit/2023-06-Index-judging/issues/21))
+ Module: Add bidder protections for `quoteAsset` and `isSellAuction` ([Sherlock Issue 27](https://github.com/sherlock-audit/2023-06-Index-judging/issues/27))
+ Module: Allow `raiseTargetPercentage` to be set to zero in `setRaiseTargetPercentage` and reset `raiseTargetPercentage` to zero in `unlock` ([Sherlock Issue 38](https://github.com/sherlock-audit/2023-06-Index-judging/issues/38))
+ Adapter: Fix exponential adapter implementation ([Sherlock Issue 39](https://github.com/sherlock-audit/2023-06-Index-judging/issues/39))
+ Warning: `block.timestamp` interpretation and L2 sequencer uptime warning ([Sherlock Issue 40](https://github.com/sherlock-audit/2023-06-Index-judging/issues/40))
+ Module: Allow option to settle remaining auction with `componentAmount = type(uint256).max` ([Sherlock Issue 41](https://github.com/sherlock-audit/2023-06-Index-judging/issues/41))
+ Adapter: Change `scalingFactor` to 18 digits with precise multiplication in logarithmic and exponential adapters ([Sherlock Issue 42](https://github.com/sherlock-audit/2023-06-Index-judging/issues/42))
+ Warning: Add warning about front-running risk when no supply cap is enforced ([Sherlock Issue 57](https://github.com/sherlock-audit/2023-06-Index-judging/issues/57))