### PR TITLE
fix(adapter): Add Auction Price Adapter Audit Remediations

### DIFF
--- a/contracts/protocol/integration/auction-price/BoundedStepwiseExponentialPriceAdapter.sol
+++ b/contracts/protocol/integration/auction-price/BoundedStepwiseExponentialPriceAdapter.sol
@@ -55,7 +55,7 @@ contract BoundedStepwiseExponentialPriceAdapter {
         uint256 timeBucket = _timeElapsed / bucketSize;
 
         // Protect against exponential argument overflow
-        if (timeBucket > type(uint256).max / timeCoefficient) {
+        if (timeBucket > uint256(type(int256).max) / timeCoefficient) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
         int256 expArgument = int256(timeCoefficient * timeBucket);
@@ -70,7 +70,7 @@ contract BoundedStepwiseExponentialPriceAdapter {
         if (scalingFactor > type(uint256).max / expExpression) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
-        uint256 priceChange = scalingFactor * expExpression - WAD;
+        uint256 priceChange = FixedPointMathLib.mulWad(scalingFactor, expExpression - WAD);
 
         if (isDecreasing) {
             // Protect against price underflow

--- a/contracts/protocol/integration/auction-price/BoundedStepwiseLogarithmicPriceAdapter.sol
+++ b/contracts/protocol/integration/auction-price/BoundedStepwiseLogarithmicPriceAdapter.sol
@@ -55,7 +55,7 @@ contract BoundedStepwiseLogarithmicPriceAdapter {
         uint256 timeBucket = _timeElapsed / bucketSize;
 
         // Protect against logarithmic argument overflow
-        if (timeBucket > type(uint256).max / timeCoefficient) {
+        if (timeBucket > uint256(type(int256).max) / timeCoefficient) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
         int256 lnArgument = int256(timeBucket * timeCoefficient);
@@ -70,7 +70,7 @@ contract BoundedStepwiseLogarithmicPriceAdapter {
         if (lnExpression > type(uint256).max / scalingFactor) {
             return _getBoundaryPrice(isDecreasing, maxPrice, minPrice);
         }
-        uint256 priceChange = scalingFactor * lnExpression;
+        uint256 priceChange = FixedPointMathLib.mulWad(scalingFactor, lnExpression);
 
         if (isDecreasing) {
             // Protect against price underflow

--- a/test/protocol/integration/auction-price/boundedStepwiseExponentialPriceAdapter.spec.ts
+++ b/test/protocol/integration/auction-price/boundedStepwiseExponentialPriceAdapter.spec.ts
@@ -48,7 +48,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getPrice", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -60,7 +60,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = true;
@@ -371,7 +371,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
       describe("when the coefficient is 0", async () => {
         beforeEach(async () => {
-          subjectCoefficient = 0;
+          subjectCoefficient = ZERO;
           subjectPriceAdapterConfigData = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             subjectInitialPrice,
             subjectCoefficient,
@@ -468,7 +468,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#isPriceAdapterConfigDataValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -479,7 +479,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -530,7 +530,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     describe("when the coefficient is 0", async () => {
       beforeEach(async () => {
-        subjectCoefficient = 0;
+        subjectCoefficient = ZERO;
         subjectPriceAdapterConfigData = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
           subjectInitialPrice,
           subjectCoefficient,
@@ -743,7 +743,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getDecodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -754,7 +754,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -802,7 +802,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
   describe("#getEncodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectCoefficient: number;
+    let subjectCoefficient: BigNumber;
     let subjectExponent: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -811,7 +811,7 @@ describe("BoundedStepwiseExponentialPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectCoefficient = 1;
+      subjectCoefficient = ether(1);
       subjectExponent = ether(1);
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;

--- a/test/protocol/integration/auction-price/boundedStepwiseLogarithmicPriceAdapter.spec.ts
+++ b/test/protocol/integration/auction-price/boundedStepwiseLogarithmicPriceAdapter.spec.ts
@@ -48,7 +48,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getPrice", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -60,7 +60,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = true;
@@ -146,7 +146,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
     describe("when the time elapsed is 0", async () => {
       beforeEach(async () => {
         subjectInitialPrice = ether(100);
-        subjectScalingFactor = 1;
+        subjectScalingFactor = ether(1);
         subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
         subjectBucketSize = ONE_HOUR_IN_SECONDS;
         subjectIsDecreasing = true;
@@ -304,7 +304,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is decreasing and the price computation will underflow", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 50;
+        subjectScalingFactor = ether(50);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
@@ -328,7 +328,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is decreasing and the price computation returns below the minimum", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 3;
+        subjectScalingFactor = ether(3);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
@@ -378,7 +378,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when it is not decreasing and the price computation returns above the maximum", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 3;
+        subjectScalingFactor = ether(3);
         subjectTimeCoefficient = subjectInitialPrice.div(2);
         subjectIsDecreasing = false;
         subjectMaxPrice = ether(110);
@@ -425,7 +425,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
       describe("when the scaling factor is 0", async () => {
         beforeEach(async () => {
-          subjectScalingFactor = 0;
+          subjectScalingFactor = ZERO;
           subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             subjectInitialPrice,
             subjectScalingFactor,
@@ -522,7 +522,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#isPriceAdapterConfigDataValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -533,7 +533,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -584,7 +584,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when the scaling factor is 0", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 0;
+        subjectScalingFactor = ZERO;
         subjectPriceAdapterConfigData = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
           subjectInitialPrice,
           subjectScalingFactor,
@@ -690,7 +690,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#areParamsValid", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectMaxPrice: BigNumber;
@@ -698,7 +698,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectMaxPrice = ether(110);
@@ -736,7 +736,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     describe("when the scaling factor is 0", async () => {
       beforeEach(async () => {
-        subjectScalingFactor = 0;
+        subjectScalingFactor = ZERO;
       });
 
       it("should return false", async () => {
@@ -797,7 +797,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getDecodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -808,7 +808,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;
@@ -856,7 +856,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
   describe("#getEncodedData", async () => {
     let subjectInitialPrice: BigNumber;
-    let subjectScalingFactor: number;
+    let subjectScalingFactor: BigNumber;
     let subjectTimeCoefficient: BigNumber;
     let subjectBucketSize: BigNumber;
     let subjectIsDecreasing: boolean;
@@ -865,7 +865,7 @@ describe("BoundedStepwiseLogarithmicPriceAdapter", () => {
 
     beforeEach(async () => {
       subjectInitialPrice = ether(100);
-      subjectScalingFactor = 1;
+      subjectScalingFactor = ether(1);
       subjectTimeCoefficient = ether(1.718281828459045235); // approx e - 1
       subjectBucketSize = ONE_HOUR_IN_SECONDS;
       subjectIsDecreasing = false;

--- a/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
+++ b/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
@@ -2977,7 +2977,7 @@ describe("AuctionRebalanceModuleV1", () => {
         beforeEach(async () => {
           const daiExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(0.0005),
-            1,
+            ether(1),
             ether(0.00001),
             ONE_HOUR_IN_SECONDS,
             true,
@@ -2988,7 +2988,7 @@ describe("AuctionRebalanceModuleV1", () => {
           const wbtcPerWethDecimalFactor = ether(1).div(bitcoin(1));
           const wbtcExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(14.5).mul(wbtcPerWethDecimalFactor),
-            1,
+            ether(1),
             ether(0.1).mul(wbtcPerWethDecimalFactor),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -2998,7 +2998,7 @@ describe("AuctionRebalanceModuleV1", () => {
 
           const wethExponentialCurveParams = await boundedStepwiseExponentialPriceAdapter.getEncodedData(
             ether(1),
-            1,
+            ether(1),
             ether(0.1),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -3164,7 +3164,7 @@ describe("AuctionRebalanceModuleV1", () => {
         beforeEach(async () => {
           const daiLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(0.0005),
-            1,
+            ether(1),
             ether(0.00001),
             ONE_HOUR_IN_SECONDS,
             true,
@@ -3175,7 +3175,7 @@ describe("AuctionRebalanceModuleV1", () => {
           const wbtcPerWethDecimalFactor = ether(1).div(bitcoin(1));
           const wbtcLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(14.5).mul(wbtcPerWethDecimalFactor),
-            1,
+            ether(1),
             ether(0.1).mul(wbtcPerWethDecimalFactor),
             ONE_HOUR_IN_SECONDS,
             false,
@@ -3185,7 +3185,7 @@ describe("AuctionRebalanceModuleV1", () => {
 
           const wethLogarithmicCurveParams = await boundedStepwiseLogarithmicPriceAdapter.getEncodedData(
             ether(1),
-            1,
+            ether(1),
             ether(0.1),
             ONE_HOUR_IN_SECONDS,
             false,


### PR DESCRIPTION
Remediations
+ Fix exponential adapter implementation ([Sherlock Issue 39](https://github.com/sherlock-audit/2023-06-Index-judging/issues/39))
+ Fix overflow checks in logarithmic and exponential adapters ([Sherlock Issue 1](https://github.com/sherlock-audit/2023-06-Index-judging/issues/1))
+ Change `scalingFactor` to 18 digits with precise multiplication in logarithmic and exponential adapters ([Sherlock Issue 42](https://github.com/sherlock-audit/2023-06-Index-judging/issues/42))