### PR TITLE
fix(module): Add Auction Module Audit Remediations

### DIFF
--- a/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
+++ b/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
@@ -290,7 +290,8 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
      * is used to push the current component units closer to the target units defined in startRebalance().
      *
      * Bidders specify the amount of the component they intend to buy or sell, and also specify the maximum/minimum amount 
-     * of the quote asset they are willing to spend/receive.
+     * of the quote asset they are willing to spend/receive. If the component amount is max uint256, the bid will fill
+     * the remaining amount to reach the target.
      *
      * The auction parameters, which are set by the manager, are used to determine the price of the component. Any bids that 
      * either don't move the component units towards the target, or overshoot the target, will be reverted.

--- a/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
+++ b/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
@@ -355,7 +355,6 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
     /**
      * @dev ACCESS LIMITED: Increases asset targets uniformly when all target units have been met but there is remaining quote asset.
      * Can be called multiple times if necessary. Targets are increased by the percentage specified by raiseAssetTargetsPercentage set by the manager.
-     * Additionally, the rebalance start time is reset to the current time, effectively restarting the rebalance duration and auction price curves. 
      * This helps in reducing tracking error and providing greater granularity in reaching an equilibrium between the excess quote asset
      * and the components to be purchased. However, excessively raising targets may result in under-allocating to the quote asset as more of
      * it is spent buying components to meet the new targets.
@@ -380,9 +379,6 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
 
         // Update the positionMultiplier in the RebalanceInfo struct
         rebalanceInfo[_setToken].positionMultiplier = newPositionMultiplier;
-
-        // Reset the auction price curves for all components
-        rebalanceInfo[_setToken].rebalanceStartTime = block.timestamp;
 
         // Emit the AssetTargetsRaised event
         emit AssetTargetsRaised(_setToken, newPositionMultiplier);

--- a/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
+++ b/contracts/protocol/modules/v1/AuctionRebalanceModuleV1.sol
@@ -45,6 +45,10 @@ import { PreciseUnitMath } from "../../../lib/PreciseUnitMath.sol";
  *
  * @dev Compatible with StreamingFeeModule and BasicIssuanceModule. Review compatibility if used
  * with additional modules.
+ * @dev WARNING: If rebalances don't lock the SetToken, there's potential for bids to be front-run
+ * by sizable issuance/redemption. This could lead to the SetToken not approaching its target allocation
+ * proportionately to the bid size. To counteract this risk, a supply cap can be applied to the SetToken,
+ * allowing regular issuance/redemption while preventing front-running with large issuance/redemption.
  * @dev WARNING: This contract does NOT support ERC-777 component tokens or quote assets.
  * @dev WARNING: Please note that the behavior of block.timestamp varies across different EVM chains. 
  * This contract does not incorporate additional checks for unique behavior or for elements like sequencer uptime. 
@@ -231,6 +235,8 @@ contract AuctionRebalanceModuleV1 is ModuleBase, ReentrancyGuard {
      * target units, e.g., in cases where fee accrual affects the positionMultiplier of the SetToken, ensuring proportional
      * allocation among components. If target allocations are not met within the specified duration, the rebalance concludes
      * with the allocations achieved.
+     * 
+     * @dev WARNING: If rebalances don't lock the SetToken, enforce a supply cap on the SetToken to prevent front-running.
      *
      * @param _setToken                     The SetToken to be rebalanced.
      * @param _quoteAsset                   ERC20 token used as the quote asset in auctions.

--- a/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
+++ b/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
@@ -1899,17 +1899,6 @@ describe("AuctionRebalanceModuleV1", () => {
           );
         });
 
-        it("should reset the auction start time", async () => {
-          const auctionStartTimeBefore = (await auctionModule.rebalanceInfo(subjectSetToken.address)).rebalanceStartTime;
-
-          const txnTimestamp = await getTransactionTimestamp(subject());
-
-          const auctionStartTimeAfter = (await auctionModule.rebalanceInfo(subjectSetToken.address)).rebalanceStartTime;
-
-          expect(auctionStartTimeAfter).to.gt(auctionStartTimeBefore);
-          expect(auctionStartTimeAfter).to.eq(txnTimestamp);
-        });
-
         describe("when the calling address is not a permissioned address", async () => {
           beforeEach(async () => {
             subjectCaller = await getRandomAccount();

--- a/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
+++ b/test/protocol/modules/v1/auctionRebalanceModuleV1.spec.ts
@@ -1577,16 +1577,27 @@ describe("AuctionRebalanceModuleV1", () => {
             defaultDuration,
             defaultPositionMultiplier
           );
+
+          await auctionModule.connect(owner.wallet).setRaiseTargetPercentage(
+            indexWithQuoteAsset.address,
+            ether(0.0001)
+          );
         });
 
-        it("should unlock the SetToken", async () => {
+        it("should unlock the SetToken and reset the raiseTargetPercentage", async () => {
           const isLockedBefore = await subjectSetToken.isLocked();
           expect(isLockedBefore).to.be.true;
+
+          const raiseTargetPercentageBefore = (await auctionModule.rebalanceInfo(subjectSetToken.address)).raiseTargetPercentage;
+          expect(raiseTargetPercentageBefore).to.gt(ZERO);
 
           await subject();
 
           const isLockedAfter = await subjectSetToken.isLocked();
           expect(isLockedAfter).to.be.false;
+
+          const raiseTargetPercentageAfter = (await auctionModule.rebalanceInfo(subjectSetToken.address)).raiseTargetPercentage;
+          expect(raiseTargetPercentageAfter).to.eq(ZERO);
         });
       });
 
@@ -1620,6 +1631,9 @@ describe("AuctionRebalanceModuleV1", () => {
 
           const isLockedAfter = await subjectSetToken.isLocked();
           expect(isLockedAfter).to.be.false;
+
+          const raiseTargetPercentageAfter = (await auctionModule.rebalanceInfo(subjectSetToken.address)).raiseTargetPercentage;
+          expect(raiseTargetPercentageAfter).to.eq(ZERO);
         });
 
         it("should emit the LockedRebalanceEndedEarly event", async () => {
@@ -1773,11 +1787,22 @@ describe("AuctionRebalanceModuleV1", () => {
 
       describe("when the target percentage is set to 0", async () => {
         beforeEach(async () => {
+          await auctionModule.connect(owner.wallet).setRaiseTargetPercentage(
+            indexWithQuoteAsset.address,
+            ether(0.001)
+          );
+
           subjectRaiseTargetPercentage = ZERO;
         });
 
-        it("should revert with 'Target percentage must be greater than 0'", async () => {
-          await expect(subject()).to.be.revertedWith("Target percentage must be greater than 0");
+        it("should set the raiseTargetPercentage", async () => {
+          const oldRaiseTargetPercentage = (await auctionModule.rebalanceInfo(subjectSetToken.address)).raiseTargetPercentage;
+          expect(oldRaiseTargetPercentage).to.eq(ether(0.001));
+
+          await subject();
+          const newRaiseTargetPercentage = (await auctionModule.rebalanceInfo(subjectSetToken.address)).raiseTargetPercentage;
+
+          expect(newRaiseTargetPercentage).to.eq(ZERO);
         });
       });
     });
@@ -1872,6 +1897,17 @@ describe("AuctionRebalanceModuleV1", () => {
             subjectSetToken.address,
             expectedPositionMultiplier
           );
+        });
+
+        it("should reset the auction start time", async () => {
+          const auctionStartTimeBefore = (await auctionModule.rebalanceInfo(subjectSetToken.address)).rebalanceStartTime;
+
+          const txnTimestamp = await getTransactionTimestamp(subject());
+
+          const auctionStartTimeAfter = (await auctionModule.rebalanceInfo(subjectSetToken.address)).rebalanceStartTime;
+
+          expect(auctionStartTimeAfter).to.gt(auctionStartTimeBefore);
+          expect(auctionStartTimeAfter).to.eq(txnTimestamp);
         });
 
         describe("when the calling address is not a permissioned address", async () => {
@@ -2320,6 +2356,63 @@ describe("AuctionRebalanceModuleV1", () => {
           );
         });
 
+        describe("when the component amount is the max uint256", async () => {
+          beforeEach(async () => {
+            subjectComponentAmount = MAX_UINT_256;
+          });
+
+          it("updates position units and transfers tokens correctly on a component sell auction with ConstantPriceAdapter", async () => {
+            const preBidBalances = {
+              bidderDai: await setup.dai.balanceOf(bidder.address),
+              bidderWeth: await setup.weth.balanceOf(bidder.address),
+              setTokenDai: await setup.dai.balanceOf(subjectSetToken.address),
+              setTokenWeth: await setup.weth.balanceOf(subjectSetToken.address)
+            };
+            const setTokenTotalSupply = await subjectSetToken.totalSupply();
+
+            await subject();
+
+            const expectedWethPositionUnits = preciseDiv(preBidBalances.setTokenWeth.add(subjectQuoteAssetLimit), setTokenTotalSupply);
+            const expectedDaiPositionUnits = preciseDiv(preBidBalances.setTokenDai.sub(ether(900)), setTokenTotalSupply);
+
+            const wethPositionUnits = await subjectSetToken.getDefaultPositionRealUnit(setup.weth.address);
+            const daiPositionUnits = await subjectSetToken.getDefaultPositionRealUnit(setup.dai.address);
+
+            expect(wethPositionUnits).to.eq(expectedWethPositionUnits);
+            expect(daiPositionUnits).to.eq(expectedDaiPositionUnits);
+
+            const postBidBalances = {
+              bidderDai: await setup.dai.balanceOf(bidder.address),
+              bidderWeth: await setup.weth.balanceOf(bidder.address),
+              setTokenDai: await setup.dai.balanceOf(subjectSetToken.address),
+              setTokenWeth: await setup.weth.balanceOf(subjectSetToken.address)
+            };
+
+            expect(postBidBalances.bidderDai).to.eq(preBidBalances.bidderDai.add(ether(900)));
+            expect(postBidBalances.bidderWeth).to.eq(preBidBalances.bidderWeth.sub(subjectQuoteAssetLimit));
+            expect(postBidBalances.setTokenDai).to.eq(preBidBalances.setTokenDai.sub(ether(900)));
+            expect(postBidBalances.setTokenWeth).to.eq(preBidBalances.setTokenWeth.add(subjectQuoteAssetLimit));
+          });
+
+          it("emits the correct BidExecuted event", async () => {
+            const totalSupply = await subjectSetToken.totalSupply();
+
+            await expect(subject()).to.emit(auctionModule, "BidExecuted").withArgs(
+              subjectSetToken.address,
+              subjectComponent,
+              defaultQuoteAsset,
+              subjectCaller.address,
+              constantPriceAdapter.address,
+              true,
+              ether(0.0005),
+              ether(900), // not the max uint256
+              subjectQuoteAssetLimit,
+              0,
+              totalSupply
+            );
+          });
+        });
+
         describe("when there is a protcol fee charged", async () => {
           let feePercentage: BigNumber;
 
@@ -2536,6 +2629,63 @@ describe("AuctionRebalanceModuleV1", () => {
             0,
             totalSupply
           );
+        });
+
+        describe("when the component amount is the max uint256", async () => {
+          beforeEach(async () => {
+            subjectComponentAmount = MAX_UINT_256;
+          });
+
+          it("updates position units and transfers tokens correctly on a component buy auction with ConstantPriceAdapter", async () => {
+            const preBidBalances = {
+              bidderWbtc: await setup.wbtc.balanceOf(bidder.address),
+              bidderWeth: await setup.weth.balanceOf(bidder.address),
+              setTokenWbtc: await setup.wbtc.balanceOf(subjectSetToken.address),
+              setTokenWeth: await setup.weth.balanceOf(subjectSetToken.address)
+            };
+            const setTokenTotalSupply = await subjectSetToken.totalSupply();
+
+            await subject();
+
+            const expectedWethPositionUnits = preciseDiv(preBidBalances.setTokenWeth.sub(subjectQuoteAssetLimit), setTokenTotalSupply);
+            const expectedWbtcPositionUnits = preciseDiv(preBidBalances.setTokenWbtc.add(bitcoin(0.1)), setTokenTotalSupply);
+
+            const wethPositionUnits = await subjectSetToken.getDefaultPositionRealUnit(setup.weth.address);
+            const wbtcPositionUnits = await subjectSetToken.getDefaultPositionRealUnit(setup.wbtc.address);
+
+            expect(wethPositionUnits).to.eq(expectedWethPositionUnits);
+            expect(wbtcPositionUnits).to.eq(expectedWbtcPositionUnits);
+
+            const postBidBalances = {
+              bidderWbtc: await setup.wbtc.balanceOf(bidder.address),
+              bidderWeth: await setup.weth.balanceOf(bidder.address),
+              setTokenWbtc: await setup.wbtc.balanceOf(subjectSetToken.address),
+              setTokenWeth: await setup.weth.balanceOf(subjectSetToken.address)
+            };
+
+            expect(postBidBalances.bidderWbtc).to.eq(preBidBalances.bidderWbtc.sub(bitcoin(0.1)));
+            expect(postBidBalances.bidderWeth).to.eq(preBidBalances.bidderWeth.add(subjectQuoteAssetLimit));
+            expect(postBidBalances.setTokenWbtc).to.eq(preBidBalances.setTokenWbtc.add(bitcoin(0.1)));
+            expect(postBidBalances.setTokenWeth).to.eq(preBidBalances.setTokenWeth.sub(subjectQuoteAssetLimit));
+          });
+
+          it("emits the correct BidExecuted event", async () => {
+            const totalSupply = await subjectSetToken.totalSupply();
+
+            await expect(subject()).to.emit(auctionModule, "BidExecuted").withArgs(
+              subjectSetToken.address,
+              defaultQuoteAsset,
+              subjectComponent,
+              subjectCaller.address,
+              constantPriceAdapter.address,
+              defaultShouldLockSetToken,
+              defaultWbtcPrice,
+              subjectQuoteAssetLimit,
+              bitcoin(0.1),
+              0,
+              totalSupply
+            );
+          });
         });
 
         describe("when there is a protcol fee charged", async () => {
@@ -3354,6 +3504,18 @@ describe("AuctionRebalanceModuleV1", () => {
 
         it("should revert with 'Rebalance must be in progress'", async () => {
           await expect(subject()).to.be.revertedWith("Rebalance must be in progress");
+        });
+      });
+
+      describe("when the component amount is zero", async () => {
+        beforeEach(async () => {
+          await startRebalance();
+
+          subjectComponentAmount = ZERO;
+        });
+
+        it("should revert with 'Component amount must be > 0'", async () => {
+          await expect(subject()).to.be.revertedWith("Component amount must be > 0");
         });
       });
 


### PR DESCRIPTION
Remediations
+ Add check to prevent bid with `componentAmount = 0` ([Sherlock Issue 6](https://github.com/sherlock-audit/2023-06-Index-judging/issues/6))
+ Allow `raiseTargetPercentage` to be set to zero in `setRaiseTargetPercentage` and reset `raiseTargetPercentage` to zero in `unlock` ([Sherlock Issue 38](https://github.com/sherlock-audit/2023-06-Index-judging/issues/38))
+ Allow option to settle remaining auction with `componentAmount = type(uint256).max` ([Sherlock Issue 41](https://github.com/sherlock-audit/2023-06-Index-judging/issues/41))
+ Add warning about front-running risk when no supply cap is enforced ([Sherlock Issue 57](https://github.com/sherlock-audit/2023-06-Index-judging/issues/57))