### PR TITLE
fix(library): Add check for return of ERC20 transfer to Invoke library

### DIFF
--- a/contracts/mocks/ERC20NoReturnMock.sol
+++ b/contracts/mocks/ERC20NoReturnMock.sol
@@ -1,0 +1,40 @@
+pragma solidity 0.6.10;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20NoReturnMock is ERC20 {
+    constructor(
+        address _initialAccount,
+        uint256 _initialBalance,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    )
+        public
+        ERC20(_name, _symbol)
+    {
+        _mint(_initialAccount, _initialBalance);
+        _setupDecimals(_decimals);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        super.transfer(to, amount);
+        assembly {
+            return(0, 0)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        super.transferFrom(from, to, amount);
+        assembly {
+            return(0, 0)
+        }
+    }
+
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        super.approve(spender, amount);
+        assembly {
+            return(0, 0)
+        }
+    }
+}

--- a/contracts/mocks/ERC20ReturnFalseMock.sol
+++ b/contracts/mocks/ERC20ReturnFalseMock.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.6.10;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20ReturnFalseMock is ERC20 {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    )
+        public
+        ERC20(_name, _symbol)
+    {
+        _setupDecimals(_decimals);
+    }
+
+    function transfer(address, uint256) public override returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256) public override returns (bool) {
+        return false;
+    }
+
+    function approve(address, uint256) public override returns (bool) {
+        return false;
+    }
+}

--- a/contracts/protocol/lib/Invoke.sol
+++ b/contracts/protocol/lib/Invoke.sol
@@ -76,7 +76,7 @@ library Invoke {
 
             bytes memory returnData = _setToken.invoke(_token, 0, callData);
             if (returnData.length > 0) {
-                require(abi.decode(returnData, (bool)), "ERC20 transfer did not succeed with false return data");
+                require(abi.decode(returnData, (bool)), "ERC20 transfer failed");
             }
         }
     }

--- a/contracts/protocol/lib/Invoke.sol
+++ b/contracts/protocol/lib/Invoke.sol
@@ -73,7 +73,11 @@ library Invoke {
     {
         if (_quantity > 0) {
             bytes memory callData = abi.encodeWithSignature("transfer(address,uint256)", _to, _quantity);
-            _setToken.invoke(_token, 0, callData);
+
+            bytes memory returnData = _setToken.invoke(_token, 0, callData);
+            if (returnData.length != 0) {
+                require(abi.decode(returnData, (bool)), "Transfer failed with false return data");
+            }
         }
     }
 

--- a/contracts/protocol/lib/Invoke.sol
+++ b/contracts/protocol/lib/Invoke.sol
@@ -75,8 +75,8 @@ library Invoke {
             bytes memory callData = abi.encodeWithSignature("transfer(address,uint256)", _to, _quantity);
 
             bytes memory returnData = _setToken.invoke(_token, 0, callData);
-            if (returnData.length != 0) {
-                require(abi.decode(returnData, (bool)), "Transfer failed with false return data");
+            if (returnData.length > 0) {
+                require(abi.decode(returnData, (bool)), "ERC20 transfer did not succeed with false return data");
             }
         }
     }

--- a/test/protocol/lib/invoke.spec.ts
+++ b/test/protocol/lib/invoke.spec.ts
@@ -141,7 +141,7 @@ describe("Invoke", () => {
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("ERC20 transfer did not succeed with false return data");
+        await expect(subject()).to.be.revertedWith("ERC20 transfer failed");
       });
     });
 

--- a/test/protocol/lib/invoke.spec.ts
+++ b/test/protocol/lib/invoke.spec.ts
@@ -141,7 +141,7 @@ describe("Invoke", () => {
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Transfer failed with false return data");
+        await expect(subject()).to.be.revertedWith("ERC20 transfer did not succeed with false return data");
       });
     });
   });

--- a/test/protocol/lib/invoke.spec.ts
+++ b/test/protocol/lib/invoke.spec.ts
@@ -133,6 +133,17 @@ describe("Invoke", () => {
         await expect(newBalance).to.eq(previousBalance);
       });
     });
+
+    describe("when the erc20 transfer call returns false", async () => {
+      beforeEach(async () => {
+        const erc20ReturnFalseMock = await deployer.mocks.deployERC20ReturnFalseMock();
+        subjectToken = erc20ReturnFalseMock.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Transfer failed with false return data");
+      });
+    });
   });
 
   describe("#strictInvokeTransfer", async () => {

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -43,6 +43,7 @@ export { DebtIssuanceModule } from "../../typechain/DebtIssuanceModule";
 export { DebtIssuanceModuleV2 } from "../../typechain/DebtIssuanceModuleV2";
 export { DebtModuleMock } from "../../typechain/DebtModuleMock";
 export { DelegateRegistry } from "../../typechain/DelegateRegistry";
+export { ERC20ReturnFalseMock } from "../../typechain/ERC20ReturnFalseMock";
 export { ERC4626Mock } from "../../typechain/ERC4626Mock";
 export { ERC4626WrapV2Adapter } from "../../typechain/ERC4626WrapV2Adapter";
 export { ExplicitERC20Mock } from "../../typechain/ExplicitERC20Mock";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -43,6 +43,7 @@ export { DebtIssuanceModule } from "../../typechain/DebtIssuanceModule";
 export { DebtIssuanceModuleV2 } from "../../typechain/DebtIssuanceModuleV2";
 export { DebtModuleMock } from "../../typechain/DebtModuleMock";
 export { DelegateRegistry } from "../../typechain/DelegateRegistry";
+export { ERC20NoReturnMock } from "../../typechain/ERC20NoReturnMock";
 export { ERC20ReturnFalseMock } from "../../typechain/ERC20ReturnFalseMock";
 export { ERC4626Mock } from "../../typechain/ERC4626Mock";
 export { ERC4626WrapV2Adapter } from "../../typechain/ERC4626WrapV2Adapter";

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -17,6 +17,7 @@ import {
   DebtIssuanceMock,
   DebtModuleMock,
   ExplicitERC20Mock,
+  ERC20NoReturnMock,
   ERC20ReturnFalseMock,
   ERC4626Mock,
   ForceFunderMock,
@@ -82,6 +83,7 @@ import { CurveStableswapMock__factory } from "../../typechain/factories/CurveSta
 import { CustomSetValuerMock__factory } from "../../typechain/factories/CustomSetValuerMock__factory";
 import { DebtIssuanceMock__factory } from "../../typechain/factories/DebtIssuanceMock__factory";
 import { DebtModuleMock__factory } from "../../typechain/factories/DebtModuleMock__factory";
+import { ERC20NoReturnMock__factory } from "../../typechain/factories/ERC20NoReturnMock__factory";
 import { ERC20ReturnFalseMock__factory } from "../../typechain/factories/ERC20ReturnFalseMock__factory";
 import { ERC4626Mock__factory } from "../../typechain/factories/ERC4626Mock__factory";
 import { ExplicitERC20Mock__factory } from "../../typechain/factories/ExplicitERC20Mock__factory";
@@ -281,6 +283,22 @@ export default class DeployMocks {
     symbol: string = "Symbol",
   ): Promise<StandardTokenMock> {
     return await new StandardTokenMock__factory(this._deployerSigner).deploy(
+      initialAccount,
+      initialBalance,
+      name,
+      symbol,
+      decimals,
+    );
+  }
+
+  public async deployERC20NoReturnMock(
+    initialAccount: Address,
+    initialBalance: BigNumberish = ether(1000000000),
+    decimals: BigNumberish = 18,
+    name: string = "Token",
+    symbol: string = "Symbol",
+  ): Promise<ERC20NoReturnMock> {
+    return await new ERC20NoReturnMock__factory(this._deployerSigner).deploy(
       initialAccount,
       initialBalance,
       name,

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -17,6 +17,7 @@ import {
   DebtIssuanceMock,
   DebtModuleMock,
   ExplicitERC20Mock,
+  ERC20ReturnFalseMock,
   ERC4626Mock,
   ForceFunderMock,
   GaugeControllerMock,
@@ -81,6 +82,7 @@ import { CurveStableswapMock__factory } from "../../typechain/factories/CurveSta
 import { CustomSetValuerMock__factory } from "../../typechain/factories/CustomSetValuerMock__factory";
 import { DebtIssuanceMock__factory } from "../../typechain/factories/DebtIssuanceMock__factory";
 import { DebtModuleMock__factory } from "../../typechain/factories/DebtModuleMock__factory";
+import { ERC20ReturnFalseMock__factory } from "../../typechain/factories/ERC20ReturnFalseMock__factory";
 import { ERC4626Mock__factory } from "../../typechain/factories/ERC4626Mock__factory";
 import { ExplicitERC20Mock__factory } from "../../typechain/factories/ExplicitERC20Mock__factory";
 import { ForceFunderMock__factory } from "../../typechain/factories/ForceFunderMock__factory";
@@ -284,6 +286,18 @@ export default class DeployMocks {
       name,
       symbol,
       decimals,
+    );
+  }
+
+  public async deployERC20ReturnFalseMock(
+    name: string = "Token",
+    symbol: string = "Symbol",
+    decimals: BigNumberish = BigNumber.from(18),
+  ): Promise<ERC20ReturnFalseMock> {
+    return await new ERC20ReturnFalseMock__factory(this._deployerSigner).deploy(
+      name,
+      symbol,
+      decimals
     );
   }
 


### PR DESCRIPTION
Check for the existence and value of the returned data of the `erc20.transfer` call to protect users from loss of funds: https://github.com/sherlock-audit/2023-05-Index-judging/issues/169

Fix references
+ Sherlock comment https://github.com/sherlock-audit/2023-05-Index-judging/issues/236#issuecomment-1639732193
+ OpenZeppelin's SafeERC20 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/b438cb695a1ac520cee6678610b161b1d5df4d9c/contracts/token/ERC20/utils/SafeERC20.sol#L99-L115