### PR TITLE
Add NAV Issuance and ERC-4626 Integration Audit Remediations

### DIFF
--- a/contracts/interfaces/external/IERC20Metadata.sol
+++ b/contracts/interfaces/external/IERC20Metadata.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.17;
+
+interface IERC20Metadata {
+    function name() external view returns (string memory);
+
+    function symbol() external view returns (string memory);
+
+    function decimals() external view returns (uint8);
+}

--- a/contracts/mocks/external/ERC4626ConverterMock.sol
+++ b/contracts/mocks/external/ERC4626ConverterMock.sol
@@ -19,19 +19,23 @@
 pragma solidity 0.6.10;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { IERC20Metadata } from "../../interfaces/IERC20Metadata.sol";
 
 contract ERC4626ConverterMock {
     using SafeMath for uint256;
 
+    IERC20Metadata public asset;
     uint256 public decimals;
     uint256 public pricePerShare;
 
-    constructor(uint256 _decimals, uint256 _pricePerShare) public {
+    constructor(IERC20Metadata _asset, uint256 _decimals, uint256 _pricePerShare) public {
+        asset = _asset;
         decimals = _decimals;
         pricePerShare = _pricePerShare;
     }
 
     function convertToAssets(uint256 shares) external view returns (uint256) {
-        return shares.mul(pricePerShare).div(10 ** decimals);
+        uint256 unnormalized = shares.mul(pricePerShare).div(1e18);
+        return unnormalized.mul(uint256(10) ** asset.decimals()).div(10 ** decimals);
     }
 }

--- a/contracts/protocol/integration/exchange/ERC4626ExchangeAdapter.sol
+++ b/contracts/protocol/integration/exchange/ERC4626ExchangeAdapter.sol
@@ -1,0 +1,93 @@
+/*
+    Copyright 2024 Index Cooperative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache-2.0	
+*/
+
+pragma solidity 0.8.17;
+
+import { IERC4626 } from "../../../interfaces/external/IERC4626.sol";
+
+/**
+ * @title ERC4626ExchangeAdapter
+ * @author Index Cooperative
+ *
+ * Exchange adapter for ERC-4626 Vaults that returns data for wraps/unwraps of tokens.
+ * 
+ * This adapter is intended to handle both no-loss wrapping and unwrapping of assets and ones 
+ * that may incur a loss in value due to fees or other factors. 
+ */
+contract ERC4626ExchangeAdapter {
+
+    /* ============ State Variables ============ */
+
+    IERC4626 public vault;
+
+    /* ========= Constructor ========== */
+
+    /**
+     * Set ERC-4626 vault address
+     * @param _vault           Address of the ERC-4626 vault
+     */
+    constructor(IERC4626 _vault) {
+        vault = _vault;
+    }
+
+    function getTradeCalldata(
+        address _sourceToken,
+        address _destinationToken,
+        address _destinationAddress,
+        uint256 _sourceQuantity,
+        uint256 /* _minDestinationQuantity  */,
+        bytes memory /* _data */
+    )
+        external
+        view
+        returns (address, uint256, bytes memory)
+    {
+        if (_sourceToken == vault.asset()) {
+            require(_destinationToken == address(vault), "Invalid destination token");
+
+            bytes memory callData = abi.encodeWithSelector(
+                IERC4626.deposit.selector, 
+                _sourceQuantity, 
+                _destinationAddress
+            );
+
+            return (address(vault), 0, callData);
+        }
+        else if (_sourceToken == address(vault)) {
+            require(_destinationToken == vault.asset(), "Invalid destination token");
+
+            bytes memory callData = abi.encodeWithSelector(
+                IERC4626.redeem.selector, 
+                _sourceQuantity, 
+                _destinationAddress,
+                _destinationAddress
+            );
+
+            return (address(vault), 0, callData);
+        }
+        else {
+            revert("Invalid source token");
+        }
+    }
+
+    function getSpender()
+        external
+        view
+        returns (address)
+    {
+        return address(vault);
+    }
+}

--- a/contracts/protocol/integration/oracles/ERC4626Oracle.sol
+++ b/contracts/protocol/integration/oracles/ERC4626Oracle.sol
@@ -26,6 +26,10 @@ import { IERC4626 } from "../../../interfaces/external/IERC4626.sol";
  * @author Index Cooperative
  *
  * Oracle built to retrieve the assets per one share of the ERC-4626 vault
+ * 
+ * @dev WARNING: ERC-4626 vaults using this oracle must be evaluated for potential 
+ * read-only reentrancy vulnerabilities in the convertToAssets function. Vaults 
+ * found to have this vulnerability should not use this oracle.
  */
 contract ERC4626Oracle {
     IERC4626 public immutable vault;

--- a/contracts/protocol/integration/oracles/ERC4626Oracle.sol
+++ b/contracts/protocol/integration/oracles/ERC4626Oracle.sol
@@ -18,6 +18,7 @@
 
 pragma solidity 0.8.17;
 
+import { IERC20Metadata } from "../../../interfaces/external/IERC20Metadata.sol";
 import { IERC4626 } from "../../../interfaces/external/IERC4626.sol";
 
 /**
@@ -34,26 +35,26 @@ contract ERC4626Oracle {
 
     /*
      * @param  _vault               The address of the ERC-4626 vault
-     * @param  _underlyingFullUnit  The full unit of the underlying asset
      * @param  _dataDescription     Human readable description of oracle
      */
     constructor(
         IERC4626 _vault,
-        uint256 _underlyingFullUnit,
         string memory _dataDescription
     ) {
+        vaultFullUnit = 10 ** _vault.decimals();
+
+        IERC20Metadata underlyingAsset = IERC20Metadata(_vault.asset());
+        underlyingFullUnit = 10 ** underlyingAsset.decimals();
+
         vault = _vault;
         dataDescription = _dataDescription;
-
-        underlyingFullUnit = _underlyingFullUnit;
-        vaultFullUnit = 10 ** _vault.decimals();
     }
 
     /**
-     * Returns the assets per one share of the vault
+     * Returns the assets per one share of the vault normalized to 18 decimals
      */
     function read() external view returns (uint256) {
         uint256 assetsPerShare = vault.convertToAssets(vaultFullUnit);
-        return assetsPerShare * vaultFullUnit / underlyingFullUnit;
+        return assetsPerShare * 1e18 / underlyingFullUnit;
     }
 }

--- a/contracts/protocol/integration/wrap-v2/ERC4626WrapV2Adapter.sol
+++ b/contracts/protocol/integration/wrap-v2/ERC4626WrapV2Adapter.sol
@@ -22,7 +22,11 @@ import { IERC4626 } from "../../../interfaces/external/IERC4626.sol";
  * @title ERC4626WrapV2Adapter
  * @author Index Cooperative
  *
- * Wrap adapter for ERC-4626 Vaults that returns data for wraps/unwraps of tokens
+ * Wrap adapter for ERC-4626 Vaults that returns data for wraps/unwraps of tokens. 
+ * 
+ * Warning: This adapter is intended only for no-loss wrapping and unwrapping of assets. It is not suitable for
+ * use with assets that may incur a loss in value due to fees or other factors. For such operations, 
+ * the TradeModule should be used.
  */
 contract ERC4626WrapV2Adapter {
 

--- a/contracts/protocol/modules/v1/CustomOracleNAVIssuanceModule.sol
+++ b/contracts/protocol/modules/v1/CustomOracleNAVIssuanceModule.sol
@@ -46,6 +46,9 @@ import { ResourceIdentifier } from "../../lib/ResourceIdentifier.sol";
  * a proportional amount of SetTokens on issuance or ERC20 token on redemption based on the calculated net asset value using
  * oracle prices. Manager is able to enforce a premium / discount on issuance / redemption to avoid arbitrage and front
  * running when relying on oracle prices. Managers can charge a fee (denominated in reserve asset).
+ * 
+ * * CHANGELOG:
+ * - 9/19/24: Introduce MAX_POSITION_MULTIPLIER to prevent precision loss
  */
 contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
     using AddressArrayUtils for address[];
@@ -154,6 +157,9 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
     mapping(ISetToken => mapping(address => bool)) public isReserveAsset;
 
     /* ============ Constants ============ */
+
+    // 1e20 is the maximum value the position multiplier can be inflated to. This is a security feature to prevent precision loss
+    int256 constant internal MAX_POSITION_MULTIPLIER = 1e20;
 
     // 0 index stores the manager fee in managerFees array, percentage charged on issue (denominated in reserve asset)
     uint256 constant internal MANAGER_ISSUE_FEE_INDEX = 0;
@@ -1034,6 +1040,9 @@ contract CustomOracleNavIssuanceModule is ModuleBase, ReentrancyGuard {
         int256 newPositionMultiplier = _setToken.positionMultiplier()
             .mul(_redeemInfo.previousSetTokenSupply.toInt256())
             .div(newTotalSupply.toInt256());
+
+        // Require inflated position multiplier does not exceed maximum
+        require(newPositionMultiplier <= MAX_POSITION_MULTIPLIER, "New position multiplier must not exceed max");
 
         return (newTotalSupply, newPositionMultiplier);
     }

--- a/contracts/protocol/modules/v1/CustomOracleNAVIssuanceModule.sol
+++ b/contracts/protocol/modules/v1/CustomOracleNAVIssuanceModule.sol
@@ -47,6 +47,10 @@ import { ResourceIdentifier } from "../../lib/ResourceIdentifier.sol";
  * oracle prices. Manager is able to enforce a premium / discount on issuance / redemption to avoid arbitrage and front
  * running when relying on oracle prices. Managers can charge a fee (denominated in reserve asset).
  * 
+ * @dev WARNING: Components using oracle adapters for NAV calculations must be evaluated for potential 
+ * read-only reentrancy vulnerabilities in the oracle's read function. Vulnerable components should 
+ * not use this module. 
+ * 
  * * CHANGELOG:
  * - 9/19/24: Introduce MAX_POSITION_MULTIPLIER to prevent precision loss
  */

--- a/contracts/protocol/modules/v1/WrapModuleV2.sol
+++ b/contracts/protocol/modules/v1/WrapModuleV2.sol
@@ -44,6 +44,10 @@ import { PreciseUnitMath } from "../../../lib/PreciseUnitMath.sol";
  *
  * Some examples of wrap actions include wrapping, DAI to cDAI (Compound) or Dai to aDai (AAVE).
  * 
+ * Warning: This module is designed solely for no-loss wrapping and unwrapping of assets. It should not be used
+ * for wrapping assets that may experience a loss in value due to fees or other factors. For such operations, 
+ * please use the TradeModule.
+ * 
  * CHANGELOG:
  * - 8/7/24: Grant and revoke max approval when unwrapping
  */

--- a/test/integration/exchange/erc4626ExchangeAdapter.spec.ts
+++ b/test/integration/exchange/erc4626ExchangeAdapter.spec.ts
@@ -1,0 +1,215 @@
+import "module-alias/register";
+
+import { BigNumber } from "ethers";
+import { Address, Bytes } from "@utils/types";
+import { Account } from "@utils/test/types";
+import { ERC4626ExchangeAdapter, IERC20, IERC20__factory } from "@typechain/index";
+import {
+  SetToken,
+  TradeModule,
+} from "@utils/contracts";
+import DeployHelper from "@utils/deploys";
+import {
+  ether,
+  usdc,
+} from "@utils/index";
+import {
+  getAccounts,
+  getSystemFixture,
+  getWaffleExpect,
+} from "@utils/test/index";
+
+import { SystemFixture } from "@utils/fixtures";
+import { MAX_UINT_256, ZERO, ZERO_BYTES } from "@utils/constants";
+import { impersonateAccount } from "@utils/test/testingUtils";
+import { forkingConfig } from "../../../hardhat.config";
+import { network } from "hardhat";
+
+const expect = getWaffleExpect();
+
+describe("ERC4626ExchangeAdapter TradeModule Integration [ @forked-mainnet ]", () => {
+  const usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+  const fUsdcAddress = "0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33";
+
+  let owner: Account;
+  let manager: Account;
+
+  let deployer: DeployHelper;
+
+  let usdcErc20: IERC20;
+  let fUsdc: IERC20;
+
+  let erc4626ExchangeAdapter: ERC4626ExchangeAdapter;
+  let erc4626ExchangeAdapterName: string;
+
+  let setup: SystemFixture;
+  let tradeModule: TradeModule;
+
+  let setToken: SetToken;
+
+  const blockNumber = 20528609;
+  before(async () => {
+    const forking = {
+      jsonRpcUrl: forkingConfig.url,
+      blockNumber,
+    };
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking,
+        },
+      ],
+    });
+  });
+  after(async () => {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  });
+
+  before(async () => {
+    [
+      owner,
+      manager,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+    setup = getSystemFixture(owner.address);
+    await setup.initialize();
+
+    usdcErc20 = IERC20__factory.connect(usdcAddress, owner.wallet);
+    fUsdc = IERC20__factory.connect(fUsdcAddress, owner.wallet);
+
+    erc4626ExchangeAdapter = await deployer.adapters.deployERC4626ExchangeAdapter(fUsdcAddress);
+    erc4626ExchangeAdapterName = "fUSDC_Exchange_Adapter";
+
+    tradeModule = await deployer.modules.deployTradeModule(setup.controller.address);
+    await setup.controller.addModule(tradeModule.address);
+
+    await setup.integrationRegistry.addIntegration(
+      tradeModule.address,
+      erc4626ExchangeAdapterName,
+      erc4626ExchangeAdapter.address
+    );
+
+    setToken = await setup.createSetToken(
+      [usdcAddress],
+      [usdc(1)],
+      [setup.issuanceModule.address, tradeModule.address],
+      manager.address
+    );
+
+    await tradeModule.connect(manager.wallet).initialize(setToken.address);
+
+    const mockPreIssuanceHook = await deployer.mocks.deployManagerIssuanceHookMock();
+    await setup.issuanceModule.connect(manager.wallet).initialize(setToken.address, mockPreIssuanceHook.address);
+
+    const issueQuantity = ether(5);
+    const usdcWhale = "0x075e72a5eDf65F0A5f44699c7654C1a76941Ddc8";
+    const usdcWhaleAccount = await impersonateAccount(usdcWhale);
+    await usdcErc20.connect(usdcWhaleAccount).approve(setup.issuanceModule.address, MAX_UINT_256);
+    await setup.issuanceModule.connect(usdcWhaleAccount).issue(setToken.address, issueQuantity, owner.address);
+  });
+
+  describe("#trade", function() {
+    context("when trading the underlying for a ERC-4626 component", async () => {
+      let subjectDestinationToken: Address;
+      let subjectSourceToken: Address;
+      let subjectSourceQuantity: BigNumber;
+      let subjectAdapterName: string;
+      let subjectSetToken: Address;
+      let subjectMinDestinationQuantity: BigNumber;
+      let subjectData: Bytes;
+      let subjectCaller: Account;
+
+      beforeEach(async () => {
+        subjectSetToken = setToken.address;
+        subjectSourceToken = usdcAddress;
+        subjectDestinationToken = fUsdcAddress;
+        subjectSourceQuantity = usdc(0.5);
+        subjectMinDestinationQuantity = usdc(0.4);
+        subjectAdapterName = erc4626ExchangeAdapterName;
+        subjectData = ZERO_BYTES;
+        subjectCaller = manager;
+      });
+
+      async function subject(): Promise<any> {
+        tradeModule = tradeModule.connect(subjectCaller.wallet);
+        return tradeModule.trade(
+          subjectSetToken,
+          subjectAdapterName,
+          subjectSourceToken,
+          subjectSourceQuantity,
+          subjectDestinationToken,
+          subjectMinDestinationQuantity,
+          subjectData
+        );
+      }
+
+      it("should transfer the correct components to and from the SetToken", async () => {
+        const beforeUnderlyingBalance = await usdcErc20.balanceOf(subjectSetToken);
+        const beforeVaultBalance = await fUsdc.balanceOf(subjectSetToken);
+        expect(beforeUnderlyingBalance).to.eq(usdc(5));
+        expect(beforeVaultBalance).to.eq(ZERO);
+
+        await subject();
+
+        const afterUnderlyingBalance = await usdcErc20.balanceOf(subjectSetToken);
+        const afterVaultBalance = await fUsdc.balanceOf(subjectSetToken);
+        expect(afterUnderlyingBalance).to.eq(usdc(2.5));
+        expect(afterVaultBalance).to.be.gt(usdc(2.3));
+      });
+    });
+
+    context("when trading the ERC-4626 component for a underlying", async () => {
+      let subjectDestinationToken: Address;
+      let subjectSourceToken: Address;
+      let subjectSourceQuantity: BigNumber;
+      let subjectAdapterName: string;
+      let subjectSetToken: Address;
+      let subjectMinDestinationQuantity: BigNumber;
+      let subjectData: Bytes;
+      let subjectCaller: Account;
+
+      beforeEach(async () => {
+        subjectSetToken = setToken.address;
+        subjectSourceToken = fUsdcAddress;
+        subjectDestinationToken = usdcAddress;
+        subjectSourceQuantity = usdc(0.4);
+        subjectMinDestinationQuantity = usdc(0.41);
+        subjectAdapterName = erc4626ExchangeAdapterName;
+        subjectData = ZERO_BYTES;
+        subjectCaller = manager;
+      });
+
+      async function subject(): Promise<any> {
+        tradeModule = tradeModule.connect(subjectCaller.wallet);
+        return tradeModule.trade(
+          subjectSetToken,
+          subjectAdapterName,
+          subjectSourceToken,
+          subjectSourceQuantity,
+          subjectDestinationToken,
+          subjectMinDestinationQuantity,
+          subjectData
+        );
+      }
+
+      it("should transfer the correct components to and from the SetToken", async () => {
+        const beforeSourceTokenBalance = await fUsdc.balanceOf(subjectSetToken);
+        const beforeDestinationTokenBalance = await usdcErc20.balanceOf(subjectSetToken);
+        expect(beforeSourceTokenBalance).to.gt(usdc(2.3));
+        expect(beforeDestinationTokenBalance).to.eq(usdc(2.5));
+
+        await subject();
+
+        const afterSourceTokenBalance = await fUsdc.balanceOf(subjectSetToken);
+        const afterDestinationTokenBalance = await usdcErc20.balanceOf(subjectSetToken);
+        expect(afterSourceTokenBalance).to.be.lt(usdc(0.35));
+        expect(afterDestinationTokenBalance).to.be.gt(usdc(4.6));
+      });
+    });
+  });
+});

--- a/test/integration/oracles/erc4626Oracle.spec.ts
+++ b/test/integration/oracles/erc4626Oracle.spec.ts
@@ -5,7 +5,7 @@ import { Address } from "@utils/types";
 import { Account } from "@utils/test/types";
 import { ERC4626ConverterMock, ERC4626Oracle } from "@utils/contracts";
 import DeployHelper from "@utils/deploys";
-import { ether, usdc } from "@utils/index";
+import { ether } from "@utils/index";
 import {
   getAccounts,
   getWaffleExpect,
@@ -21,11 +21,15 @@ describe("ERC4626Oracle", () => {
   let deployer: DeployHelper;
   let setup: SystemFixture;
 
-  let usdcVault: ERC4626ConverterMock;
+  let usdcLowDecimalVault: ERC4626ConverterMock;
+  let usdcHighDecimalVault: ERC4626ConverterMock;
+  let daiVault: ERC4626ConverterMock;
 
-  let erc4626UsdcOracle: ERC4626Oracle;
+  let erc4626UsdcLowDecimalOracle: ERC4626Oracle;
+  let erc4626UsdcHighDecimalOracle: ERC4626Oracle;
+  let erc4626DaiOracle: ERC4626Oracle;
 
-  let price: number;
+  let price: BigNumber;
 
   before(async () => {
     [
@@ -37,14 +41,23 @@ describe("ERC4626Oracle", () => {
     setup = getSystemFixture(owner.address);
     await setup.initialize();
 
-    price = 1.02;
+    price = ether(1.02);
 
-    usdcVault = await deployer.mocks.deployERC4626ConverterMock(18, usdc(price));
+    usdcLowDecimalVault = await deployer.mocks.deployERC4626ConverterMock(setup.usdc.address, 6, price);
+    usdcHighDecimalVault = await deployer.mocks.deployERC4626ConverterMock(setup.usdc.address, 18, price);
+    daiVault = await deployer.mocks.deployERC4626ConverterMock(setup.dai.address, 18, price);
 
-    erc4626UsdcOracle = await deployer.oracles.deployERC4626Oracle(
-      usdcVault.address,
-      usdc(1),
-      "usdcVault-usdc Oracle"
+    erc4626UsdcLowDecimalOracle = await deployer.oracles.deployERC4626Oracle(
+      usdcLowDecimalVault.address,
+      "usdcLowDecimalVault-usdc Oracle"
+    );
+    erc4626UsdcHighDecimalOracle = await deployer.oracles.deployERC4626Oracle(
+      usdcHighDecimalVault.address,
+      "usdcHighDecimalVault-usdc Oracle"
+    );
+    erc4626DaiOracle = await deployer.oracles.deployERC4626Oracle(
+      daiVault.address,
+      "daiVault-dai Oracle"
     );
   });
 
@@ -55,49 +68,76 @@ describe("ERC4626Oracle", () => {
     let subjectDataDescription: string;
 
     before(async () => {
-      subjectVaultAddress = usdcVault.address;
-      subjectDataDescription = "usdcVault-usdc Oracle";
+      subjectVaultAddress = daiVault.address;
+      subjectDataDescription = "daiVault-dai Oracle";
     });
 
     async function subject(): Promise<ERC4626Oracle> {
       return deployer.oracles.deployERC4626Oracle(
         subjectVaultAddress,
-        usdc(1),
         subjectDataDescription
       );
     }
 
     it("sets the correct vault address", async () => {
-      const erc4626UsdcOracle = await subject();
-      const vaultAddress = await erc4626UsdcOracle.vault();
+      const oracle = await subject();
+      const vaultAddress = await oracle.vault();
       expect(vaultAddress).to.equal(subjectVaultAddress);
     });
 
 
     it("sets the correct full units", async () => {
-      const erc4626UsdcOracle = await subject();
-      const underlyingFullUnit = await erc4626UsdcOracle.underlyingFullUnit();
-      const vaultFullUnit = await erc4626UsdcOracle.vaultFullUnit();
-      expect(underlyingFullUnit).to.eq(usdc(1));
+      const oracle = await subject();
+      const underlyingFullUnit = await oracle.underlyingFullUnit();
+      const vaultFullUnit = await oracle.vaultFullUnit();
+      expect(underlyingFullUnit).to.eq(ether(1));
       expect(vaultFullUnit).to.eq(ether(1));
     });
 
     it("sets the correct data description", async () => {
-      const erc4626UsdcOracle = await subject();
-      const actualDataDescription = await erc4626UsdcOracle.dataDescription();
+      const oracle = await subject();
+      const actualDataDescription = await oracle.dataDescription();
       expect(actualDataDescription).to.eq(subjectDataDescription);
     });
   });
 
 
   describe("#read", async () => {
+    let subjectOracle: ERC4626Oracle;
+
+    before(async () => {
+      subjectOracle = erc4626DaiOracle;
+    });
+
     async function subject(): Promise<BigNumber> {
-      return erc4626UsdcOracle.read();
+      return subjectOracle.read();
     }
 
-    it("returns the correct vault value", async () => {
+    it("returns the correct value", async () => {
       const result = await subject();
-      expect(result).to.eq(ether(price));
+      expect(result).to.eq(price);
+    });
+
+    describe("when the vault has higher decimals than the underlying", async () => {
+      beforeEach(async () => {
+        subjectOracle = erc4626UsdcHighDecimalOracle;
+      });
+
+      it("returns the correct value", async () => {
+        const result = await subject();
+        expect(result).to.eq(price);
+      });
+    });
+
+    describe("when the vault and the underlying have decimals below 18", async () => {
+      beforeEach(async () => {
+        subjectOracle = erc4626UsdcLowDecimalOracle;
+      });
+
+      it("returns the correct value", async () => {
+        const result = await subject();
+        expect(result).to.eq(price);
+      });
     });
   });
 });

--- a/test/integration/rebasingNavIssuance.spec.ts
+++ b/test/integration/rebasingNavIssuance.spec.ts
@@ -29,6 +29,9 @@ const tokenAddresses = {
   cUSDCv3: "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
   aUSDC: "0xBcca60bB61934080951369a648Fb03DF4F96263C",
   gtUSDC: "0xdd0f28e19C1780eb6396170735D45153D261490d",
+  gtCoreUsdc: "0x8eB67A509616cd6A7c1B3c8C21D48FF57df3d458",
+  steakUSDC: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+  fUsdc: "0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33",
 };
 
 const whales = {
@@ -37,6 +40,7 @@ const whales = {
   wan_liang: "0xCcb12611039c7CD321c0F23043c841F1d97287A5", // cUSDCv3
   mane_lee: "0xBF370B6E9d97D928497C2f2d72FD74f4D9ca5825", // aUSDC
   morpho_seeding: "0x6ABfd6139c7C3CC270ee2Ce132E309F59cAaF6a2", // gtUSDC
+  tipofeverest: "0x47A127f496d001f187Ac65FC24852274Dc51D080", // fUSDC
 };
 
 describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @forked-mainnet ]", () => {
@@ -53,7 +57,10 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
 
   let navIssuanceModule: CustomOracleNavIssuanceModule;
 
-  let erc4626Oracle: ERC4626Oracle;
+  let gtUsdcErc4626Oracle: ERC4626Oracle;
+  let gtCoreUsdcErc4626Oracle: ERC4626Oracle;
+  let steakUsdcErc4626Oracle: ERC4626Oracle;
+  let fUsdcErc4626Oracle: ERC4626Oracle;
 
   let setToken: SetToken;
 
@@ -62,6 +69,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
   let cUSDCv3_erc20: IERC20;
   let aUSDC_erc20: IERC20;
   let gtUSDC_erc20: IERC20;
+  let gtCoreUsdc_erc20: IERC20;
+  let steakUSDC_erc20: IERC20;
+  let fUsdc_erc20: IERC20;
 
   const blockNumber = 20528609;
   before(async () => {
@@ -99,6 +109,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
     cUSDCv3_erc20 = IERC20__factory.connect(tokenAddresses.cUSDCv3, owner.wallet);
     aUSDC_erc20 = IERC20__factory.connect(tokenAddresses.aUSDC, owner.wallet);
     gtUSDC_erc20 = IERC20__factory.connect(tokenAddresses.gtUSDC, owner.wallet);
+    gtCoreUsdc_erc20 = IERC20__factory.connect(tokenAddresses.gtCoreUsdc, owner.wallet);
+    steakUSDC_erc20 = IERC20__factory.connect(tokenAddresses.steakUSDC, owner.wallet);
+    fUsdc_erc20 = IERC20__factory.connect(tokenAddresses.fUsdc, owner.wallet);
 
     // Index Protocol setup
     debtIssuanceModule = await deployer.modules.deployDebtIssuanceModuleV3(
@@ -126,13 +139,33 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
     await setV2Setup.priceOracle.addPair(tokenAddresses.cUSDCv3, tokenAddresses.usdc, preciseUnitOracle.address);
     await setV2Setup.priceOracle.addPair(tokenAddresses.aUSDC, tokenAddresses.usdc, preciseUnitOracle.address);
 
-    erc4626Oracle = await deployer.oracles.deployERC4626Oracle(
+    gtUsdcErc4626Oracle = await deployer.oracles.deployERC4626Oracle(
       tokenAddresses.gtUSDC,
-      usdc(1),
       "gtUSDC - USDC Calculated Oracle",
     );
-    await setV2Setup.priceOracle.addAdapter(erc4626Oracle.address);
-    await setV2Setup.priceOracle.addPair(tokenAddresses.gtUSDC, tokenAddresses.usdc, erc4626Oracle.address);
+    await setV2Setup.priceOracle.addAdapter(gtUsdcErc4626Oracle.address);
+    await setV2Setup.priceOracle.addPair(tokenAddresses.gtUSDC, tokenAddresses.usdc, gtUsdcErc4626Oracle.address);
+
+    gtCoreUsdcErc4626Oracle = await deployer.oracles.deployERC4626Oracle(
+      tokenAddresses.gtCoreUsdc,
+      "gtCoreUSDC - USDC Calculated Oracle",
+    );
+    await setV2Setup.priceOracle.addAdapter(gtCoreUsdcErc4626Oracle.address);
+    await setV2Setup.priceOracle.addPair(tokenAddresses.gtCoreUsdc, tokenAddresses.usdc, gtCoreUsdcErc4626Oracle.address);
+
+    steakUsdcErc4626Oracle = await deployer.oracles.deployERC4626Oracle(
+      tokenAddresses.steakUSDC,
+      "steakUSDC - USDC Calculated Oracle",
+    );
+    await setV2Setup.priceOracle.addAdapter(steakUsdcErc4626Oracle.address);
+    await setV2Setup.priceOracle.addPair(tokenAddresses.steakUSDC, tokenAddresses.usdc, steakUsdcErc4626Oracle.address);
+
+    fUsdcErc4626Oracle = await deployer.oracles.deployERC4626Oracle(
+      tokenAddresses.fUsdc,
+      "fUSDC - USDC Calculated Oracle",
+    );
+    await setV2Setup.priceOracle.addAdapter(fUsdcErc4626Oracle.address);
+    await setV2Setup.priceOracle.addPair(tokenAddresses.fUsdc, tokenAddresses.usdc, fUsdcErc4626Oracle.address);
 
     // SetToken setup
     setToken = await setV2Setup.createSetToken(
@@ -142,6 +175,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
         tokenAddresses.cUSDCv3,
         tokenAddresses.aUSDC,
         tokenAddresses.gtUSDC,
+        tokenAddresses.gtCoreUsdc,
+        tokenAddresses.steakUSDC,
+        tokenAddresses.fUsdc,
       ],
       [
         usdc(99.6),
@@ -149,6 +185,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
         usdc(0.1),
         usdc(0.1),
         ether(0.1),
+        ether(0.1),
+        ether(0.1),
+        usdc(0.1),
       ],
       [
         debtIssuanceModule.address,
@@ -195,16 +234,23 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
     const wan_liang = await impersonateAccount(whales.wan_liang);
     const mane_lee = await impersonateAccount(whales.mane_lee);
     const morpho_seeding = await impersonateAccount(whales.morpho_seeding);
+    const tipofeverest = await impersonateAccount(whales.tipofeverest);
     await usdc_erc20.connect(justin_sun).transfer(owner.address, usdc(1000));
     await aEthUSDC_erc20.connect(justin_sun).transfer(owner.address, usdc(10000));
     await cUSDCv3_erc20.connect(wan_liang).transfer(owner.address, usdc(10000));
     await aUSDC_erc20.connect(mane_lee).transfer(owner.address, usdc(10000));
     await gtUSDC_erc20.connect(morpho_seeding).transfer(owner.address, ether(10000));
+    await gtCoreUsdc_erc20.connect(morpho_seeding).transfer(owner.address, ether(1000));
+    await steakUSDC_erc20.connect(morpho_seeding).transfer(owner.address, ether(1000));
+    await fUsdc_erc20.connect(tipofeverest).transfer(owner.address, usdc(1000));
     await usdc_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
     await aEthUSDC_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
     await cUSDCv3_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
     await aUSDC_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
     await gtUSDC_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
+    await gtCoreUsdc_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
+    await steakUSDC_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
+    await fUsdc_erc20.connect(owner.wallet).approve(debtIssuanceModule.address, MAX_UINT_256);
     await debtIssuanceModule.issue(setToken.address, ether(10), owner.address);
   });
 
@@ -227,6 +273,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const initialCUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const initialAUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const initialGTUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const initialGtCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const initialSteakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const initialFUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const initialPositionMultiplier = await setToken.positionMultiplier();
 
       await increaseTimeAsync(usdc(10));
@@ -238,6 +287,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const cUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const aUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const gtUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const gtCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const steakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const fUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const positionMultiplier = await setToken.positionMultiplier();
 
       expect(usdcUnit).to.be.eq(initialUsdcUnit);
@@ -245,6 +297,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       expect(cUsdcV3Unit).to.be.gt(initialCUsdcV3Unit);
       expect(aUsdcUnit).to.be.gt(initialAUsdcUnit);
       expect(gtUsdcUnit).to.be.eq(initialGTUsdcUnit);
+      expect(gtCoreUsdcUnit).to.be.eq(initialGtCoreUsdcUnit);
+      expect(steakUsdcUnit).to.be.eq(initialSteakUsdcUnit);
+      expect(fUsdcUnit).to.be.eq(initialFUsdcUnit);
       expect(positionMultiplier).to.be.eq(initialPositionMultiplier);
     });
   });
@@ -284,6 +339,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const initialCUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const initialAUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const initialGTUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const initialGtCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const initialSteakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const initialFUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const initialPositionMultiplier = await setToken.positionMultiplier();
 
       await increaseTimeAsync(usdc(10));
@@ -303,6 +361,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const cUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const aUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const gtUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const gtCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const steakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const fUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const positionMultiplier = await setToken.positionMultiplier();
       const usdcBalanceAfter = await usdc_erc20.balanceOf(owner.address);
       const usdcSpent = usdcBalanceBefore.sub(usdcBalanceAfter);
@@ -314,6 +375,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       expect(cUsdcV3Unit).to.be.lt(initialCUsdcV3Unit);
       expect(aUsdcUnit).to.be.lt(initialAUsdcUnit);
       expect(gtUsdcUnit).to.be.lt(initialGTUsdcUnit);
+      expect(gtCoreUsdcUnit).to.be.lt(initialGtCoreUsdcUnit);
+      expect(steakUsdcUnit).to.be.lt(initialSteakUsdcUnit);
+      expect(fUsdcUnit).to.be.lt(initialFUsdcUnit);
       expect(positionMultiplier).to.be.lt(initialPositionMultiplier);
       expect(actualOutput).to.be.lt(expectedOutputBeforeRebase);
       expect(usdcSpent).to.be.eq(subjectReserveQuantity);
@@ -355,6 +419,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const initialCUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const initialAUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const initialGTUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const initialGTCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const initialSteakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const initialFUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const initialPositionMultiplier = await setToken.positionMultiplier();
 
       await increaseTimeAsync(usdc(10));
@@ -373,6 +440,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const cUsdcV3Unit = await setToken.getDefaultPositionRealUnit(tokenAddresses.cUSDCv3);
       const aUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.aUSDC);
       const gtUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtUSDC);
+      const gtCoreUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.gtCoreUsdc);
+      const steakUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.steakUSDC);
+      const fUsdcUnit = await setToken.getDefaultPositionRealUnit(tokenAddresses.fUsdc);
       const positionMultiplier = await setToken.positionMultiplier();
       const usdcBalanceAfter = await usdc_erc20.balanceOf(owner.address);
       const actualOutput = usdcBalanceAfter.sub(usdcBalanceBefore);
@@ -383,6 +453,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       expect(cUsdcV3Unit).to.be.gt(initialCUsdcV3Unit);
       expect(aUsdcUnit).to.be.gt(initialAUsdcUnit);
       expect(gtUsdcUnit).to.be.gt(initialGTUsdcUnit);
+      expect(gtCoreUsdcUnit).to.be.gt(initialGTCoreUsdcUnit);
+      expect(steakUsdcUnit).to.be.gt(initialSteakUsdcUnit);
+      expect(fUsdcUnit).to.be.gt(initialFUsdcUnit);
       expect(positionMultiplier).to.be.gt(initialPositionMultiplier);
       expect(actualOutput).to.be.gt(expectedOutputBeforeRebase);
       expect(setTokenBalanceChange).to.be.eq(subjectSetTokenQuantity);
@@ -393,10 +466,6 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
 
     context("when the positionMultiplier is inflated past the maximum", () => {
       beforeEach(async () => {
-
-        const positionMultiplierBefore = await setToken.positionMultiplier();
-        console.log(positionMultiplierBefore.toString());
-
         await navIssuanceModule.connect(owner.wallet).redeem(
           setToken.address,
           tokenAddresses.usdc,
@@ -404,10 +473,6 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
           ZERO,
           owner.address
         );
-
-        const positionMultiplierAfter = await setToken.positionMultiplier();
-        console.log(positionMultiplierAfter.toString());
-
         subjectSetTokenQuantity = ether(0.01);
       });
 
@@ -461,6 +526,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const initialCUsdcV3Valuation = await subject(tokenAddresses.cUSDCv3);
       const initialAUsdcValuation = await subject(tokenAddresses.aUSDC);
       const initialGTUsdcValuation = await subject(tokenAddresses.gtUSDC);
+      const initialGtCoreUsdcValuation = await subject(tokenAddresses.gtCoreUsdc);
+      const initialSteakUsdcValuation = await subject(tokenAddresses.steakUSDC);
+      const initialFUsdcValuation = await subject(tokenAddresses.fUsdc);
 
       expect(initialUsdcValuation).to.be.eq(ether(99.6));
       expect(initialAEthUsdcValuation).to.be.eq(ether(0.1));
@@ -468,6 +536,12 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       expect(initialAUsdcValuation).to.be.eq(ether(0.1));
       expect(initialGTUsdcValuation).to.be.gt(ether(0.1));
       expect(initialGTUsdcValuation).to.be.lt(ether(0.11));
+      expect(initialGtCoreUsdcValuation).to.be.gt(ether(0.1));
+      expect(initialGtCoreUsdcValuation).to.be.lt(ether(0.11));
+      expect(initialSteakUsdcValuation).to.be.gt(ether(0.1));
+      expect(initialSteakUsdcValuation).to.be.lt(ether(0.11));
+      expect(initialFUsdcValuation).to.be.gt(ether(0.1));
+      expect(initialFUsdcValuation).to.be.lt(ether(0.11));
 
       await increaseTimeAsync(usdc(10));
       await rebasingComponentModule.sync(subjectSetToken);
@@ -477,6 +551,9 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       const cUsdcV3Valuation = await subject(tokenAddresses.cUSDCv3);
       const aUsdcValuation = await subject(tokenAddresses.aUSDC);
       const gtUsdcValuation = await subject(tokenAddresses.gtUSDC);
+      const gtCoreUsdcValuation = await subject(tokenAddresses.gtCoreUsdc);
+      const steakUsdcValuation = await subject(tokenAddresses.steakUSDC);
+      const fUsdcValuation = await subject(tokenAddresses.fUsdc);
 
       expect(usdcValuation).to.be.eq(ether(99.6));
       expect(aEthUsdcValuation).to.be.gt(ether(0.1));
@@ -487,6 +564,12 @@ describe("Rebasing and ERC4626 CustomOracleNavIssuanceModule integration [ @fork
       expect(aUsdcValuation).to.be.lt(ether(0.11));
       expect(gtUsdcValuation).to.be.gt(ether(0.1));
       expect(gtUsdcValuation).to.be.lt(ether(0.11));
+      expect(gtCoreUsdcValuation).to.be.gt(ether(0.1));
+      expect(gtCoreUsdcValuation).to.be.lt(ether(0.11));
+      expect(steakUsdcValuation).to.be.gt(ether(0.1));
+      expect(steakUsdcValuation).to.be.lt(ether(0.11));
+      expect(fUsdcValuation).to.be.gt(ether(0.1));
+      expect(fUsdcValuation).to.be.lt(ether(0.11));
     });
   });
 });

--- a/test/protocol/integration/exchange/erc4626ExchangeAdapter.spec.ts
+++ b/test/protocol/integration/exchange/erc4626ExchangeAdapter.spec.ts
@@ -1,0 +1,176 @@
+import "module-alias/register";
+
+import { BigNumber } from "ethers";
+import { Address, Bytes } from "@utils/types";
+import { Account } from "@utils/test/types";
+import {
+  EMPTY_BYTES,
+  ZERO,
+} from "@utils/constants";
+import { ERC4626ExchangeAdapter, ERC4626Mock, StandardTokenMock } from "@utils/contracts";
+import DeployHelper from "@utils/deploys";
+import {
+  ether,
+} from "@utils/index";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  getAccounts,
+  getRandomAddress,
+  getSystemFixture,
+  getWaffleExpect,
+} from "@utils/test/index";
+
+import { SystemFixture } from "@utils/fixtures";
+
+const expect = getWaffleExpect();
+
+describe("ERC4626ExchangeAdapter", () => {
+  let owner: Account;
+  let mockSetToken: Account;
+  let deployer: DeployHelper;
+
+  let setV2Setup: SystemFixture;
+
+  let underlyingToken: StandardTokenMock;
+  let vault: ERC4626Mock;
+
+  let erc4626ExchangeAdapter: ERC4626ExchangeAdapter;
+
+  before(async () => {
+    [
+      owner,
+      mockSetToken,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSystemFixture(owner.address);
+
+    await setV2Setup.initialize();
+
+    underlyingToken = setV2Setup.dai;
+    vault = await deployer.mocks.deployERC4626Mock("maDAI", "maDAI", setV2Setup.dai.address);
+
+    erc4626ExchangeAdapter = await deployer.adapters.deployERC4626ExchangeAdapter(vault.address);
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("constructor", async () => {
+    let subjectVault: Address;
+
+    beforeEach(async () => {
+      subjectVault = vault.address;
+    });
+
+    async function subject(): Promise<any> {
+      return await deployer.adapters.deployERC4626ExchangeAdapter(subjectVault);
+    }
+
+    it("should have the correct vault address", async () => {
+      const deployedErc4626ExchangeAdapter = await subject();
+
+      const actualVaultAddress = await deployedErc4626ExchangeAdapter.vault();
+      expect(actualVaultAddress).to.eq(vault.address);
+    });
+  });
+
+  describe("getSpender", async () => {
+    async function subject(): Promise<any> {
+      return await erc4626ExchangeAdapter.getSpender();
+    }
+
+    it("should return the correct spender address", async () => {
+      const spender = await subject();
+
+      expect(spender).to.eq(vault.address);
+    });
+  });
+
+  describe("getTradeCalldata", async () => {
+    let subjectSourceToken: Address;
+    let subjectDestinationToken: Address;
+    let subjectDestinationAddress: Address;
+    let subjectSourceQuantity: BigNumber;
+    let subjectMinDestinationQuantity: BigNumber;
+    let subjectData: Bytes;
+
+    beforeEach(async () => {
+      subjectSourceToken = underlyingToken.address;
+      subjectDestinationToken = vault.address;
+      subjectDestinationAddress = mockSetToken.address;
+      subjectSourceQuantity = ether(1);
+      subjectMinDestinationQuantity = ether(1);
+      subjectData = EMPTY_BYTES;
+    });
+
+    async function subject(): Promise<any> {
+      return await erc4626ExchangeAdapter.getTradeCalldata(
+        subjectSourceToken,
+        subjectDestinationToken,
+        subjectDestinationAddress,
+        subjectSourceQuantity,
+        subjectMinDestinationQuantity,
+        subjectData,
+      );
+    }
+
+    it("should return the correct deposit calldata", async () => {
+      const calldata = await subject();
+      const expectedCallData = vault.interface.encodeFunctionData("deposit", [
+        subjectSourceQuantity,
+        subjectDestinationAddress,
+      ]);
+      expect(JSON.stringify(calldata)).to.eq(JSON.stringify([vault.address, ZERO, expectedCallData]));
+    });
+
+    describe("when the sourceToken is the vault and the destinationToken is the underlying", async () => {
+      beforeEach(async () => {
+        subjectSourceToken = vault.address;
+        subjectDestinationToken = underlyingToken.address;
+      });
+
+      it("should return the correct redeem calldata", async () => {
+        const calldata = await subject();
+        const expectedCallData = vault.interface.encodeFunctionData("redeem", [
+          subjectSourceQuantity,
+          subjectDestinationAddress,
+          subjectDestinationAddress,
+        ]);
+        expect(JSON.stringify(calldata)).to.eq(JSON.stringify([vault.address, ZERO, expectedCallData]));
+      });
+    });
+
+    describe("when the sourceToken is neither the underlying nor the vault", async () => {
+      beforeEach(async () => {
+        subjectSourceToken = await getRandomAddress();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Invalid source token");
+      });
+    });
+
+    describe("when the sourceToken is the underlying but the destinationToken is not the vault", async () => {
+      beforeEach(async () => {
+        subjectSourceToken = underlyingToken.address;
+        subjectDestinationToken = await getRandomAddress();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Invalid destination token");
+      });
+    });
+
+    describe("when the sourceToken is the vault but the destinationToken is not the underlying", async () => {
+      beforeEach(async () => {
+        subjectSourceToken = vault.address;
+        subjectDestinationToken = await getRandomAddress();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Invalid destination token");
+      });
+    });
+  });
+});

--- a/test/protocol/setValuer.spec.ts
+++ b/test/protocol/setValuer.spec.ts
@@ -22,7 +22,7 @@ import { ADDRESS_ZERO } from "@utils/constants";
 
 const expect = getWaffleExpect();
 
-describe.only("SetValuer", () => {
+describe("SetValuer", () => {
   let owner: Account, moduleOne: Account;
   let setToken: SetToken;
   let deployer: DeployHelper;

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -49,6 +49,7 @@ export { DelegateRegistry } from "../../typechain/DelegateRegistry";
 export { ERC20NoReturnMock } from "../../typechain/ERC20NoReturnMock";
 export { ERC20ReturnFalseMock } from "../../typechain/ERC20ReturnFalseMock";
 export { ERC4626ConverterMock } from "../../typechain/ERC4626ConverterMock";
+export { ERC4626ExchangeAdapter } from "../../typechain/ERC4626ExchangeAdapter";
 export { ERC4626Mock } from "../../typechain/ERC4626Mock";
 export { ERC4626Oracle } from "../../typechain/ERC4626Oracle";
 export { ERC4626WrapV2Adapter } from "../../typechain/ERC4626WrapV2Adapter";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -14,6 +14,7 @@ import {
   CurveExchangeAdapter,
   CurveStakingAdapter,
   CurveStEthExchangeAdapter,
+  ERC4626ExchangeAdapter,
   KyberExchangeAdapter,
   KyberV3IndexExchangeAdapter,
   OneInchExchangeAdapter,
@@ -78,6 +79,7 @@ import { CompoundBravoGovernanceAdapter__factory } from "../../typechain/factori
 import { CompClaimAdapter__factory } from "../../typechain";
 import { RgtMigrationWrapAdapter__factory } from "../../typechain/factories/RgtMigrationWrapAdapter__factory";
 import { ERC4626WrapV2Adapter__factory } from "../../typechain/factories/ERC4626WrapV2Adapter__factory";
+import { ERC4626ExchangeAdapter__factory } from "../../typechain/factories/ERC4626ExchangeAdapter__factory";
 
 export default class DeployAdapters {
   private _deployerSigner: Signer;
@@ -309,6 +311,10 @@ export default class DeployAdapters {
 
   public async deployERC4626WrapV2Adapter(): Promise<ERC4626WrapV2Adapter> {
     return await new ERC4626WrapV2Adapter__factory(this._deployerSigner).deploy();
+  }
+
+  public async deployERC4626ExchangeAdapter(vault: Address): Promise<ERC4626ExchangeAdapter> {
+    return await new ERC4626ExchangeAdapter__factory(this._deployerSigner).deploy(vault);
   }
 
   public async deployCurveExchangeAdapter(

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -515,10 +515,12 @@ export default class DeployMocks {
   }
 
   public async deployERC4626ConverterMock(
+    asset: Address,
     decimals: BigNumberish,
     pricePerShare: BigNumberish,
   ): Promise<ERC4626ConverterMock> {
     return await new ERC4626ConverterMock__factory(this._deployerSigner).deploy(
+      asset,
       decimals,
       pricePerShare,
     );

--- a/utils/deploys/deployOracles.ts
+++ b/utils/deploys/deployOracles.ts
@@ -36,9 +36,8 @@ export default class DeployOracles {
 
   public async deployERC4626Oracle(
     vault: Address,
-    underlyingFullUnit: BigNumber,
     dataDescription: string): Promise<ERC4626Oracle> {
-    return await new ERC4626Oracle__factory(this._deployerSigner).deploy(vault, underlyingFullUnit, dataDescription);
+    return await new ERC4626Oracle__factory(this._deployerSigner).deploy(vault, dataDescription);
   }
 
   public async deployPreciseUnitOracle(


### PR DESCRIPTION
Audit Remediations
+ H-01: Add `positionMultiplier` inflation guard ([`7052f2c`](https://github.com/IndexCoop/index-protocol/pull/49/commits/7052f2c39aa6702eb4335e752c3838497b1a43e7))
+ M-01: Normalize `ERC4626Oracle` output ([`6f32c30`](https://github.com/IndexCoop/index-protocol/pull/49/commits/6f32c300d88501aa3163e7a8eaf34fad20a3c643))
+ M-02: Add `ERC4626ExchangeAdapter` to handle vaults with slippage ([`98c2c9c`](https://github.com/IndexCoop/index-protocol/pull/49/commits/98c2c9c831cc1b01d737fe81cec0b9f26bd61cbf))